### PR TITLE
bitem::parse: fixup uncaught exception.

### DIFF
--- a/bencode.cc
+++ b/bencode.cc
@@ -19,7 +19,7 @@ PHP_METHOD(bitem, parse)
         RETURN_NULL();
     }
     std::string ben_str(ben, ben_len);
-    RETURN_ZVAL(bitem::parse(ben_str), 1, 1);
+    CALL_AND_HANDLE(RETURN_ZVAL(bitem::parse(ben_str), 1, 1));
 }
 PHP_METHOD(bitem, load)
 {
@@ -29,7 +29,7 @@ PHP_METHOD(bitem, load)
         RETURN_NULL();
     }
     std::string file_path_str(file_path, file_path_len);
-    RETURN_ZVAL(bitem::load(file_path_str), 1, 1);
+    CALL_AND_HANDLE(RETURN_ZVAL(bitem::load(file_path_str), 1, 1));
 }
 PHP_METHOD(bitem, save)
 {
@@ -210,7 +210,7 @@ PHP_METHOD(bdict, parse)
     if (!ben_len) RETURN_NULL();
     std::string tmp(ben, ben_len);
     size_t pt = 0;
-    RETURN_ZVAL(bdict::parse(tmp, pt), 1, 1);
+    CALL_AND_HANDLE(RETURN_ZVAL(bdict::parse(tmp, pt), 1, 1));
 }
 PHP_METHOD(bdict, encode)
 {
@@ -228,7 +228,7 @@ PHP_METHOD(bdict, search)
     }
     std::string tmp(needle, needle_len);
     bdict_object *intern = Z_BDICT_OBJ_P(getThis());
-    RETURN_ZVAL(intern->bnode_data->search(tmp, mode, ""), 1, 1);
+    CALL_AND_HANDLE(RETURN_ZVAL(intern->bnode_data->search(tmp, mode, ""), 1, 1));
 }
 PHP_METHOD(bdict, to_array)
 {
@@ -425,7 +425,7 @@ PHP_METHOD(blist, parse)
     if (!ben_len) RETURN_NULL();
     std::string tmp(ben, ben_len);
     size_t pt = 0;
-    RETURN_ZVAL(blist::parse(tmp, pt), 1, 1);
+    CALL_AND_HANDLE(RETURN_ZVAL(blist::parse(tmp, pt), 1, 1));
 }
 PHP_METHOD(blist, encode)
 {
@@ -443,7 +443,7 @@ PHP_METHOD(blist, search)
     }
     std::string tmp(needle, needle_len);
     blist_object *intern = Z_BLIST_OBJ_P(getThis());
-    RETURN_ZVAL(intern->bnode_data->search(tmp, mode, ""), 1, 1);
+    CALL_AND_HANDLE(RETURN_ZVAL(intern->bnode_data->search(tmp, mode, ""), 1, 1));
 }
 PHP_METHOD(blist, to_array)
 {
@@ -544,7 +544,7 @@ PHP_METHOD(bstr, parse)
     if (!ben_len) RETURN_NULL();
     std::string tmp(ben);
     size_t pt = 0;
-    RETURN_ZVAL(bstr::parse(tmp, pt), 1, 1);
+    CALL_AND_HANDLE(RETURN_ZVAL(bstr::parse(tmp, pt), 1, 1));
 }
 PHP_METHOD(bstr, encode)
 {
@@ -641,7 +641,7 @@ PHP_METHOD(bint, parse)
     if (!ben_len) RETURN_NULL();
     std::string tmp(ben, ben_len);
     size_t pt = 0;
-    RETURN_ZVAL(bint::parse(tmp, pt), 1, 1);
+    CALL_AND_HANDLE(RETURN_ZVAL(bint::parse(tmp, pt), 1, 1));
 }
 PHP_METHOD(bint, encode)
 {

--- a/php_bencode.h
+++ b/php_bencode.h
@@ -18,4 +18,22 @@ PHP_MSHUTDOWN_FUNCTION(bencode);
 extern zend_module_entry bencode_module_entry;
 #define phpext_bencode_ptr &bencode_module_entry
 
+#define CALL_AND_HANDLE(expr)                                                                                   \
+    try {                                                                                                       \
+        return (expr);                                                                                          \
+    } catch (const std::invalid_argument& ia) {                                                                 \
+        zend_throw_exception(NULL, std::string("Invalid argument: " + std::string(ia.what())).c_str(), 2);      \
+        RETURN_NULL();                                                                                          \
+    } catch (const std::out_of_range& oor) {                                                                    \
+        zend_throw_exception(NULL, std::string("Out of Range error: " + std::string(oor.what())).c_str(), 3);   \
+        RETURN_NULL();                                                                                          \
+    } catch (const std::exception& e) {                                                                         \
+        zend_throw_exception(NULL, std::string("Undefined error: " + std::string(e.what())).c_str(), 4);        \
+        RETURN_NULL();                                                                                          \
+    } catch (...) {                                                                                             \
+        zend_throw_exception(NULL, "Unkown error", 5);                                                          \
+        RETURN_NULL();                                                                                          \
+    }                                                                                                           \
+
+
 #endif


### PR DESCRIPTION
    std::stoull may throw an exception cause php terminated.
    for example:
```php
    bitem::parse('d5:infod6:lengthi364e4:name8:test.rare3:inti1548400939e4:listl5:UTF-83:GBKe6:string13:uTorrent/3130e');
```
    exception:
```
    terminate called after throwing an instance of 'std::invalid_argument'
```