### PR TITLE
Add PHP 8.0 support

### DIFF
--- a/src/bdict.cc
+++ b/src/bdict.cc
@@ -24,7 +24,7 @@ bdict::bdict(const bdict *that)
          zend_hash_has_more_elements(that->_data) == SUCCESS;
          zend_hash_move_forward(that->_data)) {
         zval tmp;
-        ZVAL_OBJ(&tmp, zend_container::bnode_object_clone(zend_hash_get_current_data(that->_data)));
+        ZVAL_OBJ(&tmp, zend_container::bnode_object_clone(VAL_OR_OBJ(zend_hash_get_current_data(that->_data))));
         zend_string *_str_index;
         zend_ulong _num_index;
         zend_hash_get_current_key(that->_data, &_str_index, &_num_index);
@@ -68,7 +68,7 @@ void bdict::set(const std::string &key, zval *value)
     zend_object *clone_object = NULL;
     if (class_name == "bdict" || class_name == "blist" ||
         class_name == "bstr" || class_name == "bint") {
-        clone_object = zend_container::bnode_object_clone(value);
+        clone_object = zend_container::bnode_object_clone(VAL_OR_OBJ(value));
     } else {
         return;
     }
@@ -127,7 +127,7 @@ void bdict::set_path(const std::string &key, size_t &pt, zval *value)
         std::string sub_class_name = zend_container::bnode_object_get_class_name(subnode);
         if (sub_class_name == "bstr" || sub_class_name == "bint") {
             if (pt >= key.length()) {
-                zend_object *clone_object = zend_container::bnode_object_clone(value);
+                zend_object *clone_object = zend_container::bnode_object_clone(VAL_OR_OBJ(value));
                 zval *tmp = new zval();
                 ZVAL_OBJ(tmp, clone_object);
                 zend_hash_str_update(_data, current_key.c_str(), current_key.length(), tmp);
@@ -142,7 +142,7 @@ void bdict::set_path(const std::string &key, size_t &pt, zval *value)
         }
     } else {
         if (pt >= key.length()) {
-            zend_object *clone_object = zend_container::bnode_object_clone(value);
+            zend_object *clone_object = zend_container::bnode_object_clone(VAL_OR_OBJ(value));
             zval *tmp = new zval();
             ZVAL_OBJ(tmp, clone_object);
             zend_hash_str_add(_data, current_key.c_str(), current_key.length(), tmp);

--- a/src/bencode.cc
+++ b/src/bencode.cc
@@ -79,10 +79,10 @@ PHP_METHOD(bitem, save)
 }
 static zend_function_entry bitem_methods[] = {
     /* clang-format off */
-    PHP_ME(bitem, __construct,          NULL, ZEND_ACC_PUBLIC | ZEND_ACC_CTOR)
-    PHP_ME(bitem, parse,                NULL, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
-    PHP_ME(bitem, load,                 NULL, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
-    PHP_ME(bitem, save,                 NULL, ZEND_ACC_PUBLIC)
+    PHP_ME(bitem, __construct,          arginfo_void, ZEND_ACC_PUBLIC | ZEND_ACC_CTOR)
+    PHP_ME(bitem, parse,                arginfo_void, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
+    PHP_ME(bitem, load,                 arginfo_void, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
+    PHP_ME(bitem, save,                 arginfo_void, ZEND_ACC_PUBLIC)
     {NULL, NULL, NULL}
     /* clang-format on */
 };
@@ -136,7 +136,7 @@ PHP_METHOD(bdict, get_copy)
     bdict_object *intern = Z_BDICT_OBJ_P(getThis());
     std::string _key(key, key_len);
     zval zv = intern->bnode_data->get(_key);
-    RETURN_OBJ(zend_container::bnode_object_clone(&zv));
+    RETURN_OBJ(zend_container::bnode_object_clone(VAL_OR_OBJ2(zv)));
 }
 PHP_METHOD(bdict, get_path_copy)
 {
@@ -149,7 +149,7 @@ PHP_METHOD(bdict, get_path_copy)
     std::string _key(key, key_len);
     size_t pt = 0;
     zval zv = intern->bnode_data->get_path(_key, pt);
-    RETURN_OBJ(zend_container::bnode_object_clone(&zv));
+    RETURN_OBJ(zend_container::bnode_object_clone(VAL_OR_OBJ2(zv)));
 }
 PHP_METHOD(bdict, set)
 {
@@ -275,26 +275,26 @@ PHP_METHOD(bdict, __toString)
 }
 static zend_function_entry bdict_methods[] = {
     /* clang-format off */
-    PHP_ME(bdict, __construct,          NULL, ZEND_ACC_PUBLIC | ZEND_ACC_CTOR)
-    PHP_ME(bdict, get_type,             NULL, ZEND_ACC_PUBLIC)
-    PHP_ME(bdict, get,                  NULL, ZEND_ACC_PUBLIC)
-    PHP_ME(bdict, get_path,             NULL, ZEND_ACC_PUBLIC)
-    PHP_ME(bdict, get_copy,             NULL, ZEND_ACC_PUBLIC)
-    PHP_ME(bdict, get_path_copy,        NULL, ZEND_ACC_PUBLIC)
-    PHP_ME(bdict, set,                  NULL, ZEND_ACC_PUBLIC)
-    PHP_ME(bdict, set_path,             NULL, ZEND_ACC_PUBLIC)
-    PHP_ME(bdict, has,                  NULL, ZEND_ACC_PUBLIC)
-    PHP_ME(bdict, del,                  NULL, ZEND_ACC_PUBLIC)
-    PHP_ME(bdict, del_path,             NULL, ZEND_ACC_PUBLIC)
-    PHP_ME(bdict, length,               NULL, ZEND_ACC_PUBLIC)
-    PHP_ME(bdict, count,                NULL, ZEND_ACC_PUBLIC)
-    PHP_ME(bdict, parse,                NULL, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
-    PHP_ME(bdict, encode,               NULL, ZEND_ACC_PUBLIC)
-    PHP_ME(bitem, save,                 NULL, ZEND_ACC_PUBLIC)
-    PHP_ME(bdict, search,               NULL, ZEND_ACC_PUBLIC)
-    PHP_ME(bdict, to_array,             NULL, ZEND_ACC_PUBLIC)
-    PHP_ME(bdict, to_meta_array,        NULL, ZEND_ACC_PUBLIC)
-    PHP_ME(bdict, __toString,           NULL, ZEND_ACC_PUBLIC)
+    PHP_ME(bdict, __construct,          arginfo_void, ZEND_ACC_PUBLIC | ZEND_ACC_CTOR)
+    PHP_ME(bdict, get_type,             arginfo_void, ZEND_ACC_PUBLIC)
+    PHP_ME(bdict, get,                  arginfo_void, ZEND_ACC_PUBLIC)
+    PHP_ME(bdict, get_path,             arginfo_void, ZEND_ACC_PUBLIC)
+    PHP_ME(bdict, get_copy,             arginfo_void, ZEND_ACC_PUBLIC)
+    PHP_ME(bdict, get_path_copy,        arginfo_void, ZEND_ACC_PUBLIC)
+    PHP_ME(bdict, set,                  arginfo_void, ZEND_ACC_PUBLIC)
+    PHP_ME(bdict, set_path,             arginfo_void, ZEND_ACC_PUBLIC)
+    PHP_ME(bdict, has,                  arginfo_void, ZEND_ACC_PUBLIC)
+    PHP_ME(bdict, del,                  arginfo_void, ZEND_ACC_PUBLIC)
+    PHP_ME(bdict, del_path,             arginfo_void, ZEND_ACC_PUBLIC)
+    PHP_ME(bdict, length,               arginfo_void, ZEND_ACC_PUBLIC)
+    PHP_ME(bdict, count,                arginfo_void, ZEND_ACC_PUBLIC)
+    PHP_ME(bdict, parse,                arginfo_void, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
+    PHP_ME(bdict, encode,               arginfo_void, ZEND_ACC_PUBLIC)
+    PHP_ME(bitem, save,                 arginfo_void, ZEND_ACC_PUBLIC)
+    PHP_ME(bdict, search,               arginfo_void, ZEND_ACC_PUBLIC)
+    PHP_ME(bdict, to_array,             arginfo_void, ZEND_ACC_PUBLIC)
+    PHP_ME(bdict, to_meta_array,        arginfo_void, ZEND_ACC_PUBLIC)
+    PHP_ME(bdict, __toString,           arginfo_void, ZEND_ACC_PUBLIC)
     {NULL, NULL, NULL}
     /* clang-format on */
 };
@@ -350,7 +350,7 @@ PHP_METHOD(blist, get_copy)
     }
     blist_object *intern = Z_BLIST_OBJ_P(getThis());
     zval zv = intern->bnode_data->get(key);
-    RETURN_OBJ(zend_container::bnode_object_clone(&zv));
+    RETURN_OBJ(zend_container::bnode_object_clone(VAL_OR_OBJ2(zv)));
 }
 PHP_METHOD(blist, get_path_copy)
 {
@@ -363,7 +363,7 @@ PHP_METHOD(blist, get_path_copy)
     std::string _key(key, key_len);
     size_t pt = 0;
     zval zv = intern->bnode_data->get_path(_key, pt);
-    RETURN_OBJ(zend_container::bnode_object_clone(&zv));
+    RETURN_OBJ(zend_container::bnode_object_clone(VAL_OR_OBJ2(zv)));
 }
 PHP_METHOD(blist, add)
 {
@@ -499,27 +499,27 @@ PHP_METHOD(blist, __toString)
 }
 static zend_function_entry blist_methods[] = {
     /* clang-format off */
-    PHP_ME(blist, __construct,          NULL, ZEND_ACC_PUBLIC | ZEND_ACC_CTOR)
-    PHP_ME(blist, get_type,             NULL, ZEND_ACC_PUBLIC)
-    PHP_ME(blist, get,                  NULL, ZEND_ACC_PUBLIC)
-    PHP_ME(blist, get_path,             NULL, ZEND_ACC_PUBLIC)
-    PHP_ME(blist, get_copy,             NULL, ZEND_ACC_PUBLIC)
-    PHP_ME(blist, get_path_copy,        NULL, ZEND_ACC_PUBLIC)
-    PHP_ME(blist, add,                  NULL, ZEND_ACC_PUBLIC)
-    PHP_ME(blist, set,                  NULL, ZEND_ACC_PUBLIC)
-    PHP_ME(blist, set_path,             NULL, ZEND_ACC_PUBLIC)
-    PHP_ME(blist, has,                  NULL, ZEND_ACC_PUBLIC)
-    PHP_ME(blist, del,                  NULL, ZEND_ACC_PUBLIC)
-    PHP_ME(blist, del_path,             NULL, ZEND_ACC_PUBLIC)
-    PHP_ME(blist, length,               NULL, ZEND_ACC_PUBLIC)
-    PHP_ME(blist, count,                NULL, ZEND_ACC_PUBLIC)
-    PHP_ME(blist, parse,                NULL, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
-    PHP_ME(blist, encode,               NULL, ZEND_ACC_PUBLIC)
-    PHP_ME(bitem, save,                 NULL, ZEND_ACC_PUBLIC)
-    PHP_ME(blist, search,               NULL, ZEND_ACC_PUBLIC)
-    PHP_ME(blist, to_array,             NULL, ZEND_ACC_PUBLIC)
-    PHP_ME(blist, to_meta_array,        NULL, ZEND_ACC_PUBLIC)
-    PHP_ME(blist, __toString,           NULL, ZEND_ACC_PUBLIC)
+    PHP_ME(blist, __construct,          arginfo_void, ZEND_ACC_PUBLIC | ZEND_ACC_CTOR)
+    PHP_ME(blist, get_type,             arginfo_void, ZEND_ACC_PUBLIC)
+    PHP_ME(blist, get,                  arginfo_void, ZEND_ACC_PUBLIC)
+    PHP_ME(blist, get_path,             arginfo_void, ZEND_ACC_PUBLIC)
+    PHP_ME(blist, get_copy,             arginfo_void, ZEND_ACC_PUBLIC)
+    PHP_ME(blist, get_path_copy,        arginfo_void, ZEND_ACC_PUBLIC)
+    PHP_ME(blist, add,                  arginfo_void, ZEND_ACC_PUBLIC)
+    PHP_ME(blist, set,                  arginfo_void, ZEND_ACC_PUBLIC)
+    PHP_ME(blist, set_path,             arginfo_void, ZEND_ACC_PUBLIC)
+    PHP_ME(blist, has,                  arginfo_void, ZEND_ACC_PUBLIC)
+    PHP_ME(blist, del,                  arginfo_void, ZEND_ACC_PUBLIC)
+    PHP_ME(blist, del_path,             arginfo_void, ZEND_ACC_PUBLIC)
+    PHP_ME(blist, length,               arginfo_void, ZEND_ACC_PUBLIC)
+    PHP_ME(blist, count,                arginfo_void, ZEND_ACC_PUBLIC)
+    PHP_ME(blist, parse,                arginfo_void, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
+    PHP_ME(blist, encode,               arginfo_void, ZEND_ACC_PUBLIC)
+    PHP_ME(bitem, save,                 arginfo_void, ZEND_ACC_PUBLIC)
+    PHP_ME(blist, search,               arginfo_void, ZEND_ACC_PUBLIC)
+    PHP_ME(blist, to_array,             arginfo_void, ZEND_ACC_PUBLIC)
+    PHP_ME(blist, to_meta_array,        arginfo_void, ZEND_ACC_PUBLIC)
+    PHP_ME(blist, __toString,           arginfo_void, ZEND_ACC_PUBLIC)
     {NULL, NULL, NULL}
     /* clang-format on */
 };
@@ -615,17 +615,17 @@ PHP_METHOD(bstr, __toString)
 }
 static zend_function_entry bstr_methods[] = {
     /* clang-format off */
-    PHP_ME(bstr, __construct,           NULL, ZEND_ACC_PUBLIC | ZEND_ACC_CTOR)
-    PHP_ME(bstr, get_type,              NULL, ZEND_ACC_PUBLIC)
-    PHP_ME(bstr, get,                   NULL, ZEND_ACC_PUBLIC)
-    PHP_ME(bstr, set,                   NULL, ZEND_ACC_PUBLIC)
-    PHP_ME(bstr, length,                NULL, ZEND_ACC_PUBLIC)
-    PHP_ME(bstr, parse,                 NULL, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
-    PHP_ME(bstr, encode,                NULL, ZEND_ACC_PUBLIC)
-    PHP_ME(bitem, save,                 NULL, ZEND_ACC_PUBLIC)
-    PHP_ME(bstr, to_array,              NULL, ZEND_ACC_PUBLIC)
-    PHP_ME(bstr, to_meta_array,         NULL, ZEND_ACC_PUBLIC)
-    PHP_ME(bstr, __toString,            NULL, ZEND_ACC_PUBLIC)
+    PHP_ME(bstr, __construct,           arginfo_void, ZEND_ACC_PUBLIC | ZEND_ACC_CTOR)
+    PHP_ME(bstr, get_type,              arginfo_void, ZEND_ACC_PUBLIC)
+    PHP_ME(bstr, get,                   arginfo_void, ZEND_ACC_PUBLIC)
+    PHP_ME(bstr, set,                   arginfo_void, ZEND_ACC_PUBLIC)
+    PHP_ME(bstr, length,                arginfo_void, ZEND_ACC_PUBLIC)
+    PHP_ME(bstr, parse,                 arginfo_void, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
+    PHP_ME(bstr, encode,                arginfo_void, ZEND_ACC_PUBLIC)
+    PHP_ME(bitem, save,                 arginfo_void, ZEND_ACC_PUBLIC)
+    PHP_ME(bstr, to_array,              arginfo_void, ZEND_ACC_PUBLIC)
+    PHP_ME(bstr, to_meta_array,         arginfo_void, ZEND_ACC_PUBLIC)
+    PHP_ME(bstr, __toString,            arginfo_void, ZEND_ACC_PUBLIC)
     {NULL, NULL, NULL}
     /* clang-format on */
 };
@@ -717,17 +717,17 @@ PHP_METHOD(bint, __toString)
 }
 static zend_function_entry bint_methods[] = {
     /* clang-format off */
-    PHP_ME(bint, __construct,           NULL, ZEND_ACC_PUBLIC | ZEND_ACC_CTOR)
-    PHP_ME(bint, get_type,              NULL, ZEND_ACC_PUBLIC)
-    PHP_ME(bint, get,                   NULL, ZEND_ACC_PUBLIC)
-    PHP_ME(bint, set,                   NULL, ZEND_ACC_PUBLIC)
-    PHP_ME(bint, length,                NULL, ZEND_ACC_PUBLIC)
-    PHP_ME(bint, parse,                 NULL, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
-    PHP_ME(bint, encode,                NULL, ZEND_ACC_PUBLIC)
-    PHP_ME(bitem, save,                 NULL, ZEND_ACC_PUBLIC)
-    PHP_ME(bint, to_array,              NULL, ZEND_ACC_PUBLIC)
-    PHP_ME(bint, to_meta_array,         NULL, ZEND_ACC_PUBLIC)
-    PHP_ME(bint, __toString,            NULL, ZEND_ACC_PUBLIC)
+    PHP_ME(bint, __construct,           arginfo_void, ZEND_ACC_PUBLIC | ZEND_ACC_CTOR)
+    PHP_ME(bint, get_type,              arginfo_void, ZEND_ACC_PUBLIC)
+    PHP_ME(bint, get,                   arginfo_void, ZEND_ACC_PUBLIC)
+    PHP_ME(bint, set,                   arginfo_void, ZEND_ACC_PUBLIC)
+    PHP_ME(bint, length,                arginfo_void, ZEND_ACC_PUBLIC)
+    PHP_ME(bint, parse,                 arginfo_void, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
+    PHP_ME(bint, encode,                arginfo_void, ZEND_ACC_PUBLIC)
+    PHP_ME(bitem, save,                 arginfo_void, ZEND_ACC_PUBLIC)
+    PHP_ME(bint, to_array,              arginfo_void, ZEND_ACC_PUBLIC)
+    PHP_ME(bint, to_meta_array,         arginfo_void, ZEND_ACC_PUBLIC)
+    PHP_ME(bint, __toString,            arginfo_void, ZEND_ACC_PUBLIC)
     {NULL, NULL, NULL}
     /* clang-format on */
 };

--- a/src/binit.h
+++ b/src/binit.h
@@ -25,9 +25,9 @@
         intern->std.handlers = &zend_container::bclass##_object_handlers;                                \
         return &intern->std;                                                                             \
     }                                                                                                    \
-    zend_object *zend_container::bclass##_object_clone(zval *object TSRMLS_DC)                           \
+    zend_object *zend_container::bclass##_object_clone(clone_obj_t *object TSRMLS_DC)                    \
     {                                                                                                    \
-        bclass##_object *old_object = zend_container::bclass##_fetch_object(Z_OBJ_P(object));            \
+        bclass##_object *old_object = zend_container::bclass##_fetch_object(FETCH_OBJ(object));          \
         zend_object *new_zend_object = zend_container::bclass##_object_new(zend_container::bclass##_ce); \
         bclass##_object *new_object = zend_container::bclass##_fetch_object(new_zend_object);            \
         bclass *new_object_data = new bclass(old_object->bnode_data);                                    \

--- a/src/blist.cc
+++ b/src/blist.cc
@@ -23,7 +23,7 @@ blist::blist(const blist *that)
          zend_hash_has_more_elements(that->_data) == SUCCESS;
          zend_hash_move_forward(that->_data)) {
         zval tmp;
-        ZVAL_OBJ(&tmp, zend_container::bnode_object_clone(zend_hash_get_current_data(that->_data)));
+        ZVAL_OBJ(&tmp, zend_container::bnode_object_clone(VAL_OR_OBJ(zend_hash_get_current_data(that->_data))));
         zend_string *str_index;
         zend_ulong num_index;
         zend_hash_get_current_key(that->_data, &str_index, &num_index);
@@ -67,7 +67,7 @@ void blist::add(zval *value)
     zend_object *clone_object = NULL;
     if (class_name == "bdict" || class_name == "blist" ||
         class_name == "bstr" || class_name == "bint") {
-        clone_object = zend_container::bnode_object_clone(value);
+        clone_object = zend_container::bnode_object_clone(VAL_OR_OBJ(value));
     } else {
         return;
     }
@@ -82,7 +82,7 @@ void blist::set(const size_t &key, zval *value)
     zend_object *clone_object = NULL;
     if (class_name == "bdict" || class_name == "blist" ||
         class_name == "bstr" || class_name == "bint") {
-        clone_object = zend_container::bnode_object_clone(value);
+        clone_object = zend_container::bnode_object_clone(VAL_OR_OBJ(value));
     } else {
         return;
     }
@@ -105,7 +105,7 @@ bool blist::del(const size_t &key)
                     zend_hash_index_del(_data, i);
                 }
                 zval *copy_next = new zval();
-                ZVAL_OBJ(copy_next, zend_container::bnode_object_clone(zend_hash_index_find(_data, i + 1)));
+                ZVAL_OBJ(copy_next, zend_container::bnode_object_clone(VAL_OR_OBJ(zend_hash_index_find(_data, i + 1))));
                 zend_hash_index_update(_data, i, copy_next);
             }
             zend_hash_index_del(_data, constant_count);
@@ -163,7 +163,7 @@ void blist::set_path(const std::string &key, size_t &pt, zval *value)
         std::string sub_class_name = zend_container::bnode_object_get_class_name(subnode);
         if (sub_class_name == "bstr" || sub_class_name == "bint") {
             if (pt >= key.length()) {
-                zend_object *clone_object = zend_container::bnode_object_clone(value);
+                zend_object *clone_object = zend_container::bnode_object_clone(VAL_OR_OBJ(value));
                 zval *tmp = new zval();
                 ZVAL_OBJ(tmp, clone_object);
                 zend_hash_index_update(_data, current_key_long, tmp);
@@ -178,7 +178,7 @@ void blist::set_path(const std::string &key, size_t &pt, zval *value)
         }
     } else {
         if (pt >= key.length()) {
-            zend_object *clone_object = zend_container::bnode_object_clone(value);
+            zend_object *clone_object = zend_container::bnode_object_clone(VAL_OR_OBJ(value));
             zval *tmp = new zval();
             ZVAL_OBJ(tmp, clone_object);
             zend_hash_next_index_insert(_data, tmp);


### PR DESCRIPTION
Apparently PHP 8 is slightly faster on ARM, so I decided to test it and noticed that your module fails to compile. 
After few hours of googling I managed to compile it for PHP 8. All tests passed, so I assume everything is OK.
If you think that code can be unified better, feel free to modify that PR.