### PR TITLE
PHP 8.2

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -22,13 +22,13 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        php-version: ["8.1", "8.0", "7.4", "7.3"]
+        php-version: ["8.2", "8.1", "8.0", "7.4", "7.3"]
 
     steps:
       - uses: actions/checkout@v3
 
       - name: Cancel Previous Runs
-        if: contains(matrix.os, 'ubuntu') && contains(matrix.php-version, '8.1')
+        if: contains(matrix.os, 'ubuntu') && contains(matrix.php-version, '8.2')
         uses: styfle/cancel-workflow-action@0.11.0
         with:
           access_token: ${{ github.token }}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,6 +22,10 @@ before_script:
     paths:
       - modules/bencode.so
 
+php82:
+  extends: .php
+  image: php:8.2
+
 php81:
   extends: .php
   image: php:8.1

--- a/src/bencode.cc
+++ b/src/bencode.cc
@@ -294,7 +294,7 @@ static zend_function_entry bdict_methods[] = {
     PHP_ME(bdict, search,               arginfo_void, ZEND_ACC_PUBLIC)
     PHP_ME(bdict, to_array,             arginfo_void, ZEND_ACC_PUBLIC)
     PHP_ME(bdict, to_meta_array,        arginfo_void, ZEND_ACC_PUBLIC)
-    PHP_ME(bdict, __toString,           arginfo_void, ZEND_ACC_PUBLIC)
+    PHP_ME(bdict, __toString,           arginfo_void, ZEND_ACC_PUBLIC | ZEND_ACC_HAS_RETURN_TYPE)
     {NULL, NULL, NULL}
     /* clang-format on */
 };
@@ -519,7 +519,7 @@ static zend_function_entry blist_methods[] = {
     PHP_ME(blist, search,               arginfo_void, ZEND_ACC_PUBLIC)
     PHP_ME(blist, to_array,             arginfo_void, ZEND_ACC_PUBLIC)
     PHP_ME(blist, to_meta_array,        arginfo_void, ZEND_ACC_PUBLIC)
-    PHP_ME(blist, __toString,           arginfo_void, ZEND_ACC_PUBLIC)
+    PHP_ME(blist, __toString,           arginfo_void, ZEND_ACC_PUBLIC | ZEND_ACC_HAS_RETURN_TYPE)
     {NULL, NULL, NULL}
     /* clang-format on */
 };
@@ -625,7 +625,7 @@ static zend_function_entry bstr_methods[] = {
     PHP_ME(bitem, save,                 arginfo_void, ZEND_ACC_PUBLIC)
     PHP_ME(bstr, to_array,              arginfo_void, ZEND_ACC_PUBLIC)
     PHP_ME(bstr, to_meta_array,         arginfo_void, ZEND_ACC_PUBLIC)
-    PHP_ME(bstr, __toString,            arginfo_void, ZEND_ACC_PUBLIC)
+    PHP_ME(bstr, __toString,            arginfo_void, ZEND_ACC_PUBLIC | ZEND_ACC_HAS_RETURN_TYPE)
     {NULL, NULL, NULL}
     /* clang-format on */
 };
@@ -727,7 +727,7 @@ static zend_function_entry bint_methods[] = {
     PHP_ME(bitem, save,                 arginfo_void, ZEND_ACC_PUBLIC)
     PHP_ME(bint, to_array,              arginfo_void, ZEND_ACC_PUBLIC)
     PHP_ME(bint, to_meta_array,         arginfo_void, ZEND_ACC_PUBLIC)
-    PHP_ME(bint, __toString,            arginfo_void, ZEND_ACC_PUBLIC)
+    PHP_ME(bint, __toString,            arginfo_void, ZEND_ACC_PUBLIC | ZEND_ACC_HAS_RETURN_TYPE)
     {NULL, NULL, NULL}
     /* clang-format on */
 };


### PR DESCRIPTION
# Description

<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`7f8c458`](https://github.com/Frederick888/php-bencode/pull/12/commits/7f8c45878e7f23e25d8a1563d9f837b90666b5a6) Fix __toString() implemented without string return type warning



### [`9e0e41f`](https://github.com/Frederick888/php-bencode/pull/12/commits/9e0e41f66242c1c8ff003b4c18087f80964e7f01) Add PHP 8.2 to CI



<!-- === GH HISTORY FENCE === -->

# Checklist

- [x] I have rebased my branch so that it has no conflicts
- [ ] I have added tests where appropriate

# Is this a breaking change?

<!-- Yes / No. Reason. -->
No
