### PR TITLE
Add PHP 8.3 to CI; chores

### DIFF
--- a/.github/workflows/gh-ph.yml
+++ b/.github/workflows/gh-ph.yml
@@ -1,7 +1,11 @@
 name: Pull request history
 
 on:
-  pull_request:
+  pull_request_target:
+
+permissions:
+  contents: read
+  pull-requests: write
 
 jobs:
   gh-ph:

--- a/.github/workflows/gh-ph.yml
+++ b/.github/workflows/gh-ph.yml
@@ -12,7 +12,7 @@ jobs:
     name: Add commit history to pull request description
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - uses: Frederick888/gh-ph@v1

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -25,7 +25,7 @@ jobs:
         php-version: ["8.2", "8.1", "8.0", "7.4", "7.3"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Cancel Previous Runs
         if: contains(matrix.os, 'ubuntu') && contains(matrix.php-version, '8.2')

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -22,13 +22,13 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        php-version: ["8.2", "8.1", "8.0", "7.4", "7.3"]
+        php-version: ["8.3", "8.2", "8.1", "8.0", "7.4", "7.3"]
 
     steps:
       - uses: actions/checkout@v4
 
       - name: Cancel Previous Runs
-        if: contains(matrix.os, 'ubuntu') && contains(matrix.php-version, '8.2')
+        if: contains(matrix.os, 'ubuntu') && contains(matrix.php-version, '8.3')
         uses: styfle/cancel-workflow-action@0.11.0
         with:
           access_token: ${{ github.token }}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,6 +22,10 @@ before_script:
     paths:
       - modules/bencode.so
 
+php83:
+  extends: .php
+  image: php:8.3
+
 php82:
   extends: .php
   image: php:8.2


### PR DESCRIPTION
# Changes
<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`c521955`](https://github.com/Frederick888/php-bencode/pull/13/commits/c5219555821d15db08d076917ad8ca68fa029615) Allow gh-ph to run on PRs from forks

[1] https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target


### [`d5bb3b5`](https://github.com/Frederick888/php-bencode/pull/13/commits/d5bb3b5251dfe8fe0ddcfb01c139fe97a5284967) Bump actions/checkout to v4



### [`a9ba41b`](https://github.com/Frederick888/php-bencode/pull/13/commits/a9ba41b593761f22b46ab1790a3045e2043b4e96) Add PHP 8.3 to CI



<!-- === GH HISTORY FENCE === -->

# Checklist

- [x] I have rebased my branch so that it has no conflicts
- [ ] I have added tests where appropriate

# Is this a breaking change?

<!-- Yes / No. Reason. -->
No
